### PR TITLE
Add support for fully custom torch ML/MM models

### DIFF
--- a/AmberTools25-patch/qm2_extern_torchani_module.F90
+++ b/AmberTools25-patch/qm2_extern_torchani_module.F90
@@ -23,6 +23,7 @@ use torchani, only : &
     torchani_calc_energy_force_qbc, &
     torchani_calc_data_for_monitored_mlmm, &
     torchani_calc_energy_force_with_coupling, &
+    torchani_calc_energy_force_custom_mlmm, &
     torchani_energy_force_atomic_charges, &
     torchani_energy_force_atomic_charges_with_derivatives
 implicit none
@@ -184,7 +185,7 @@ subroutine get_torchani_forces(&
     dqmcharges = 0.0d0
     ! QM charges are initialied as the FF charges, but may be modified by torchani
     qmcharges = qmmm_struct%qm_resp_charges / amber_charge_units_to_au
-    if (ani_nml%use_torch_coupling) then
+    if (ani_nml%use_torch_coupling .or. ani_nml%mlmm_coupling == 2) then
         ! In this case torch handles both the in-vacuo energy calculation and the ML/MM coupling,
         ! No need to retrieve the in-vacuo energies separately
         continue
@@ -258,12 +259,22 @@ subroutine get_torchani_forces(&
     if (write_to_mdout_this_step .and. (ani_nml%use_switching_function)) then
         write(6,'(1x,"QM: IN VACUO ENERGY = ",f14.4)') ext_escf
     end if
-    if (write_to_mdout_this_step .and. (.not. ani_nml%use_torch_coupling)) then
+    if (write_to_mdout_this_step .and. (.not. ani_nml%use_torch_coupling) .and. (ani_nml%mlmm_coupling /= 2)) then
         write(6,'(1x,"TORCHANI: IN VACUO ENERGY = ",f14.4)') escf
     end if
 
     if (qmmm_nml%qmmm_int == 1) then
-        if (ani_nml%use_torch_coupling) then
+        if (ani_nml%mlmm_coupling == 2) then
+            call get_energies_and_forces_through_custom_mlmm_model( &
+                write_to_mdout_this_step, &
+                qmcoords, &
+                clcoords, &
+                qmmm_nml%qmcharge, &
+                dxyzqm, &
+                dxyzcl, &
+                escf &
+            )
+        else if (ani_nml%use_torch_coupling) then
             call get_vacuum_and_coupling_energies_and_forces_through_torchani( &
                 write_to_mdout_this_step, &
                 qmcoords, &
@@ -806,7 +817,7 @@ subroutine ani_nml_validate(ani_nml, qmmm_int, ml_system_charge)
             write(6,*) "     The electrostatic coupling approximation will be used"
             write(6,*) "     The QM energies and forces will be also corrected"
         else
-            ! Check coupling kind. Options are: 0 (coulombic), or 1 (simple polarizable)
+            ! Check coupling kind. Options are: 0 (coulombic), 1 (simple polarizable), 2 (custom model)
             if (ani_nml%mlmm_coupling == 0) then
                 write(6,*) "TORCHANI: Will use a coulombic-only QM/MM interaction energy, with no polarization corrections"
             elseif (ani_nml%mlmm_coupling == 1) then
@@ -814,25 +825,43 @@ subroutine ani_nml_validate(ani_nml, qmmm_int, ml_system_charge)
                 write(6,*) "     Thole-inspired correction terms will be added to the coulombic interaction"
                 write(6,*) "     This partially accounts for QM-region electrostatic polarization and distortion"
                 write(6,*) "     If you use this setting please cite 'https://doi.org/10.1021/acs.jcim.4c00478'"
+            elseif (ani_nml%mlmm_coupling == 2) then
+                write(6,*) "TORCHANI: Will use a fully custom ML/MM model (mlmm_coupling=2)"
+                write(6,*) "     The model must export 'compute_mlmm'; it receives ML species+coords and MM coords+charges"
+                write(6,*) "     and returns the total energy (Hartree). Forces via autograd."
+                if (ani_nml%use_extcoupling) then
+                    call ani_nml_error('mlmm_coupling=2 is incompatible with use_extcoupling')
+                endif
+                if (ani_nml%use_torchani_charges) then
+                    call ani_nml_error('mlmm_coupling=2: the custom model handles charges internally; set use_torchani_charges=.false.')
+                endif
+                if (ani_nml%write_charges) then
+                    call ani_nml_error('mlmm_coupling=2: custom model returns no charges; set write_charges=.false.')
+                endif
+                if (ani_nml%write_charges_grad) then
+                    call ani_nml_error('mlmm_coupling=2: custom model returns no charges; set write_charges_grad=.false.')
+                endif
             else
-                call ani_nml_error('Valid mlmm_coupling values are mlmm_coupling = 0 (coulombic), 1|2 (simple polarizable)')
+                call ani_nml_error('Valid mlmm_coupling values are 0 (coulombic), 1 (simple polarizable), 2 (custom model)')
             endif
-            ! Check charges kind. Options are: torchani-charges topology-charges
-            if (ani_nml%use_torchani_charges) then
-                write(6,*) "TORCHANI: Will use position-dependent NN-predicted charges for the QM-region, taking into account dq/dr"
-                if (.not. ani_nml%use_charges_derivatives) then
-                    write(6,*) "TORCHANI: *THE FOLLOWING IS MOST LIKELY AN ERROR, PLEASE CHECK YOUR INPUT!*"
-                    write(6,*) "     Disregarding charge derivatives w.r.t coords"
-                endif
-                if (ani_nml%mlmm_coupling == 0) then
-                    write(6,*) "TORCHANI WARNING: *YOU ARE USING AN UNTESTED PROTOCOL. MAKE SURE THIS IS WHAT YOU INTEND*"
-                    write(6,*) "     The selected 'coulombic-only coupling' is only tested with fixed topology charges"
-                endif
-            else
-                write(6,*) "TORCHANI: Will use fixed charges read from the topology file for the QM-region"
-                if (ani_nml%mlmm_coupling == 1) then
-                    write(6,*) "TORCHANI WARNING: *YOU ARE USING AN UNTESTED PROTOCOL. MAKE SURE THIS IS WHAT YOU INTEND*"
-                    write(6,*) "     The selected 'simple polarizable coupling' approx is only tested with NN-predicted charges"
+            ! Check charges kind for mlmm_coupling 0 and 1 only
+            if (ani_nml%mlmm_coupling /= 2) then
+                if (ani_nml%use_torchani_charges) then
+                    write(6,*) "TORCHANI: Will use position-dependent NN-predicted charges for the QM-region, taking into account dq/dr"
+                    if (.not. ani_nml%use_charges_derivatives) then
+                        write(6,*) "TORCHANI: *THE FOLLOWING IS MOST LIKELY AN ERROR, PLEASE CHECK YOUR INPUT!*"
+                        write(6,*) "     Disregarding charge derivatives w.r.t coords"
+                    endif
+                    if (ani_nml%mlmm_coupling == 0) then
+                        write(6,*) "TORCHANI WARNING: *YOU ARE USING AN UNTESTED PROTOCOL. MAKE SURE THIS IS WHAT YOU INTEND*"
+                        write(6,*) "     The selected 'coulombic-only coupling' is only tested with fixed topology charges"
+                    endif
+                else
+                    write(6,*) "TORCHANI: Will use fixed charges read from the topology file for the QM-region"
+                    if (ani_nml%mlmm_coupling == 1) then
+                        write(6,*) "TORCHANI WARNING: *YOU ARE USING AN UNTESTED PROTOCOL. MAKE SURE THIS IS WHAT YOU INTEND*"
+                        write(6,*) "     The selected 'simple polarizable coupling' approx is only tested with NN-predicted charges"
+                    endif
                 endif
             endif
         end if
@@ -862,6 +891,8 @@ subroutine ani_nml_print(ani_nml, qmmm_int, use_internal_opts)
             write(6,*) 'TORCHANI:  mlmm_coupling                ', 0, "(coulombic)"
         elseif (ani_nml%mlmm_coupling == 1) then
             write(6,*) 'TORCHANI:  mlmm_coupling                ', 1, "(simple polarizable)"
+        elseif (ani_nml%mlmm_coupling == 2) then
+            write(6,*) 'TORCHANI:  mlmm_coupling                ', 2, "(custom model)"
         else
             call internal_error()
         endif
@@ -962,6 +993,50 @@ subroutine get_vacuum_and_coupling_energies_and_forces_through_torchani( &
         write(6,'(1x,"TORCHANI: QM/MM ENERGY (TOTAL) =",f14.4)') ene_pot_embed_total
     endif
     ! Invert dxyzqm and cl because torchani returns forces, and sander expects grad
+    dxyzqm = -dxyzqm
+    dxyzcl = -dxyzcl
+endsubroutine
+
+! Fully custom ML/MM model path (mlmm_coupling=2).
+! The TorchScript model receives ML species+coords and the sander-provided
+! cutoff-filtered MM coords+charges, and returns the total energy.
+! Forces on both regions are computed by C++ via autograd.
+! Note: MM coordinates are already in correct periodic images (handled by sander
+! before this call), so use_pbc is always .false. here.
+subroutine get_energies_and_forces_through_custom_mlmm_model( &
+    write_to_mdout_this_step, &
+    qmcoords, &
+    clcoords, &
+    ml_system_charge, &
+    dxyzqm, &
+    dxyzcl, &
+    escf &
+)
+    logical, intent(in)             :: write_to_mdout_this_step
+    integer, intent(in)             :: ml_system_charge
+    double precision, intent(in)    :: qmcoords(:, :)   ! (3, n_ml)
+    double precision, intent(in)    :: clcoords(:, :)   ! (4, n_mm): rows 1-3 = coords, row 4 = charge
+    double precision, intent(inout) :: dxyzqm(:, :)
+    double precision, intent(inout) :: dxyzcl(:, :)
+    double precision, intent(inout) :: escf
+
+    call torchani_calc_energy_force_custom_mlmm( &
+        size(qmcoords, 2), &
+        size(clcoords, 2), &
+        qmcoords, &
+        clcoords(:3, :), &
+        clcoords(4, :), &
+        dummy_ucell, &
+        .false., &
+        ml_system_charge, &
+        dxyzqm, &
+        dxyzcl, &
+        escf &
+    )
+    if (write_to_mdout_this_step) then
+        write(6,'(1x,"TORCHANI: CUSTOM MLMM TOTAL ENERGY = ",f14.4)') escf
+    endif
+    ! sander expects gradients; torchani returns forces
     dxyzqm = -dxyzqm
     dxyzcl = -dxyzcl
 endsubroutine

--- a/include/torchani.h
+++ b/include/torchani.h
@@ -156,4 +156,22 @@ void torchani_calc_energy_force_with_coupling(
     double* ene_pot_embed_coulomb_buf,
     double* ene_pot_total_buf
 );
+
+// Custom ML/MM model: the TorchScript model receives ML species+coords and MM
+// coords+charges and computes the total energy internally. The model must export
+// a 'compute_mlmm' method (see README). Forces on both regions via autograd.
+void torchani_calc_energy_force_custom_mlmm(
+    int num_atoms,
+    int num_env_charges,
+    double coords_buf[][3],              // shape (num_atoms, 3)
+    double env_charge_coords_buf[][3],   // shape (num_env_charges, 3)
+    double env_charges_buf[],            // shape (num_env_charges,)
+    double cell_buf[3][3],               // shape (3, 3); ignored when use_pbc==false
+    bool use_pbc,
+    int ml_system_charge,
+    /* outputs */
+    double forces_on_atoms_buf[][3],        // shape (num_atoms, 3)
+    double forces_on_env_charges_buf[][3],  // shape (num_env_charges, 3)
+    double* ene_pot_total_buf
+);
 }

--- a/src-fortran/torchani.F90
+++ b/src-fortran/torchani.F90
@@ -22,6 +22,7 @@ public :: &
     torchani_energy_force_atomic_charges_with_derivatives, &
     torchani_calc_energy_force_with_coupling, &
     torchani_calc_data_for_monitored_mlmm, &
+    torchani_calc_energy_force_custom_mlmm, &
     convert_sander_neighborlist_to_ani_fmt, &
     torchani_dump_walltime, &
     convert_pmemd_neighborlist_to_ani_fmt
@@ -307,6 +308,35 @@ subroutine internal_energy_force_with_coupling( &
     real(c_double), intent(out) :: ene_pot_embed_dist
     real(c_double), intent(out) :: ene_pot_embed_coulomb
     real(c_double), intent(out) :: ene_pot_total
+endsubroutine
+
+subroutine internal_calc_energy_force_custom_mlmm( &
+    num_atoms, &
+    num_env_charges, &
+    coords, &
+    env_charge_coords, &
+    env_charges, &
+    cell, &
+    use_pbc, &
+    ml_system_charge, &
+    ! Outputs
+    forces_on_atoms, &
+    forces_on_env_charges, &
+    ene_pot_total &
+) bind(c, name="torchani_calc_energy_force_custom_mlmm")
+    use, intrinsic :: iso_c_binding
+    integer(c_int), value, intent(in)  :: num_atoms
+    integer(c_int), value, intent(in)  :: num_env_charges
+    real(c_double), intent(in)         :: coords(*)
+    real(c_double), intent(in)         :: env_charge_coords(*)
+    real(c_double), intent(in)         :: env_charges(*)
+    real(c_double), intent(in)         :: cell(*)
+    logical(c_bool), value, intent(in) :: use_pbc
+    integer(c_int), value, intent(in)  :: ml_system_charge
+    ! Outputs
+    real(c_double), intent(out)        :: forces_on_atoms(*)
+    real(c_double), intent(out)        :: forces_on_env_charges(*)
+    real(c_double), intent(out)        :: ene_pot_total
 endsubroutine
 endinterface
 
@@ -903,6 +933,48 @@ logical(c_bool) function fbool_to_cbool(fbool) result(ret)
         ret = .false._c_bool
     endif
 endfunction
+
+subroutine torchani_calc_energy_force_custom_mlmm( &
+    num_atoms, &
+    num_env_charges, &
+    coords, &
+    env_charge_coords, &
+    env_charges, &
+    cell, &
+    use_pbc, &
+    ml_system_charge, &
+    ! Outputs
+    forces_on_atoms, &
+    forces_on_env_charges, &
+    ene_pot_total &
+)
+    integer, value, intent(in)                      :: num_atoms
+    integer, value, intent(in)                      :: num_env_charges
+    integer, value, intent(in)                      :: ml_system_charge
+    double precision, contiguous, intent(in)        :: coords(:, :)
+    double precision, contiguous, intent(in)        :: env_charge_coords(:, :)
+    double precision, contiguous, intent(in)        :: env_charges(:)
+    double precision, contiguous, intent(in)        :: cell(:, :)
+    logical, intent(in)                             :: use_pbc
+    ! Outputs
+    double precision, contiguous, intent(out)       :: forces_on_atoms(:, :)
+    double precision, contiguous, intent(out)       :: forces_on_env_charges(:, :)
+    double precision, intent(out)                   :: ene_pot_total
+
+    call internal_calc_energy_force_custom_mlmm( &
+        num_atoms, &
+        num_env_charges, &
+        coords, &
+        env_charge_coords, &
+        env_charges, &
+        cell, &
+        fbool_to_cbool(use_pbc), &
+        ml_system_charge, &
+        forces_on_atoms, &
+        forces_on_env_charges, &
+        ene_pot_total &
+    )
+endsubroutine
 
 subroutine torchani_dump_walltime()
     ! State, clock count rate is assumed to be constant between calls

--- a/src/torchani.cpp
+++ b/src/torchani.cpp
@@ -153,6 +153,26 @@ std::vector<torch::jit::IValue> setup_inputs_nopbc(
     };
 }
 
+std::vector<torch::jit::IValue> setup_inputs_custom_mlmm(
+    torch::Tensor& ml_coords,
+    torch::Tensor& mm_coords,
+    torch::Tensor& mm_charges,
+    torch::Tensor& cell,
+    bool use_pbc,
+    int ml_system_charge
+) {
+    torch::jit::IValue cell_ival = use_pbc ? torch::jit::IValue(cell) : torch::jit::IValue();
+    torch::jit::IValue pbc_ival = use_pbc ? torch::jit::IValue(config.enabled_pbc()) : torch::jit::IValue();
+    return {
+        std::tuple{torchani_atomic_numbers, ml_coords},
+        /* mm_coords= */ mm_coords,
+        /* mm_charges= */ mm_charges,
+        /* cell= */ cell_ival,
+        /* pbc= */ pbc_ival,
+        /* charge= */ ml_system_charge
+    };
+}
+
 void calculate_and_populate_charge_derivatives(
     torch::Tensor& coords,
     torch::Tensor& atomic_charges_tensor,
@@ -548,11 +568,17 @@ void torchani_initialize(
     }
 
     // This is only necessary for double precision, since
-    // the buffers / parameters are kFloat by default
-    model.to(config.dtype());
+    // the buffers / parameters are kFloat by default.
+    // Skip for custom MLMM models (those exporting compute_mlmm): they are
+    // pre-compiled at the intended dtype, and C++ module.to() converts ALL
+    // tensor attributes unconditionally — including integer index buffers
+    // (triu_index, conv_tensor, _n_ref, _species_map, …) which must stay int64.
+    if (!model.find_method("compute_mlmm").has_value()) {
+        model.to(config.dtype());
 #ifdef DEBUG
-    std::cout << "Cast model to the specified precision" << '\n';
+        std::cout << "Cast model to the specified precision" << '\n';
 #endif
+    }
 
     // Set the correct model configuration
     if (network_index != -1) {
@@ -931,6 +957,42 @@ void torchani_energy_force_with_coupling(
     );
 }
 
+
+void torchani_calc_energy_force_custom_mlmm(
+    int num_atoms,
+    int num_env_charges,
+    double coords_buf[][3],
+    double env_charge_coords_buf[][3],
+    double env_charges_buf[],
+    double cell_buf[3][3],
+    bool use_pbc,
+    int ml_system_charge,
+    /* outputs */
+    double forces_on_atoms_buf[][3],
+    double forces_on_env_charges_buf[][3],
+    double* ene_pot_total_buf
+) {
+    if (!model.find_method("compute_mlmm").has_value()) {
+        std::cerr << "ERROR (libtorchani)\n"
+                  << "mlmm_coupling=2 requires the model to export 'compute_mlmm(...)'. "
+                  << "See the torchani-amber README for the required signature." << std::endl;
+        std::exit(2);
+    }
+    torch::Tensor ml_coords = dbl_buf_to_coords_tensor(config, coords_buf, num_atoms);
+    torch::Tensor mm_coords = dbl_buf_to_coords_tensor(config, env_charge_coords_buf, num_env_charges);
+    torch::Tensor mm_charges = dbl_buf_to_tensor(config, env_charges_buf, {1, num_env_charges});
+    torch::Tensor cell = dbl_buf_to_cell_tensor(config, cell_buf);
+
+    auto inputs = setup_inputs_custom_mlmm(ml_coords, mm_coords, mm_charges, cell, use_pbc, ml_system_charge);
+    torch::jit::IValue output = model.get_method("compute_mlmm")(inputs);
+    torch::Tensor energy = output.toTensor();
+
+    calculate_and_populate_embedding_forces(
+        energy, ml_coords, mm_coords, num_atoms, num_env_charges,
+        forces_on_atoms_buf, forces_on_env_charges_buf
+    );
+    populate_potential_energy(energy, ene_pot_total_buf);
+}
 
 void torchani_energy_force_atomic_charges_with_derivatives(
     int num_atoms,


### PR DESCRIPTION
Adds a new ML/MM coupling mode in which a TorchScript model is responsible for the ML/MM energy including both the ML in-vacuo term and the ML-MM interaction. 

Selected via the existing `&ani` namelist: `mlmm_coupling=2`. The user-supplied model must export a `compute_mlmm(...)` TorchScript method that receives the ML species+coords and the sander-provided cutoff-filtered MM coords+charges and returns the total energy. Forces on both regions are obtained by autograd on the C++ side.

Compatible models can be produced with the `emle-compile` tool from the [emle-engine](https://github.com/chemle/emle-engine) package (currently on `devel` branch).

## Changes

- **`include/torchani.h` / `src/torchani.cpp`**: new C entry point `torchani_calc_energy_force_custom_mlmm(...)` that invokes `model.compute_mlmm(...)` and runs autograd via the existing embedding-force helper. The `model.to(dtype)` cast is skipped for custom MLMM models, since it would also convert int64 index buffers (`triu_index`, `conv_tensor`, `_n_ref`, `_species_map`, ...) that must stay integral; these models are expected to be saved at the intended dtype.
- **`src-fortran/torchani.F90`**: matching Fortran wrapper and `bind(c)` interface.
- **`AmberTools25-patch/qm2_extern_torchani_module.F90`**: new dispatch in `get_torchani_forces` for `mlmm_coupling=2`; `ani_nml_validate` accepts the new value and rejects incompatible options (`use_extcoupling`, `use_torchani_charges`, `write_charges`, `write_charges_grad`).

## Required model signature

```
compute_mlmm(
    (species, ml_coords),     # tuple[Tensor int64 (1, n_ml), Tensor (1, n_ml, 3)]
    mm_coords,                # Tensor (1, n_mm, 3)
    mm_charges,               # Tensor (1, n_mm)
    cell,                     # Tensor (3, 3) or None
    pbc,                      # Tensor (3,) bool or None
    charge,                   # int (ML system net charge)
) -> Tensor                   # scalar total energy in Hartree
```

Units follow the existing torchani-amber convention (Å for coords, e for charges, Hartree for energy).

## Backwards compatibility

No behavior change for existing `mlmm_coupling=0|1` or full-ML (`iextpot=1|2`) paths. The new code path is only reached when `mlmm_coupling=2` is explicitly set.
